### PR TITLE
Actualize Interfacing with ABRT section

### DIFF
--- a/interfacing.rst
+++ b/interfacing.rst
@@ -30,6 +30,16 @@ Mandatory keys:
 * ``backtrace`` — `(string)`
 * ``reason`` — `(string)` reason of the crash
 
+To ensure the problem can be reported to Bugzilla via report-gtk or
+report-cli you have to add the following keys with the following contents:
+
+* ``duphash`` - `(string)` duplicate hash, hash is placed in Bugzilla's
+``Whiteboard`` field in format ``abrt_hash:$duphash``. Content of ``duphash``
+is for C/C++ a sha1 of joined names of top 6 functions on the stacktrace. For
+Python exception is a sha1 of the stacktrace.
+* ``uuid`` - `(string)` local identifier of the problem. The content can be the
+same as for ``duphash``.
+
 Optionally, server accepts other elements listed in :ref:`elements`.
 
 If there's no error server will respond with::


### PR DESCRIPTION
Duphash and uuid element have to be presented in dump dir in the case you want
to report it via report-gtk or report-cli.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>