### PR TITLE
Update FAQ: systemctl usage

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -24,12 +24,12 @@ What to do when ABRT is not able to catch the crash of my application?
   - ``abrtd``
   - ``abrt-ccpp``
 
-  ``$ systemctl status abrtd && systemctl status abrt-ccpp``
+  ``$ systemctl status abrtd abrt-ccpp``
 
 - If one of them is not running you can use the following command to
   restart both of them:
 
-  ``$ systemctl restart abrtd && systemctl restart abrt-ccpp``
+  ``$ sudo systemctl restart abrtd abrt-ccpp``
 
 - If the above doesn't help, consult ``journactl`` or ``/var/log/messages`` for error logs.
 


### PR DESCRIPTION
When a service is not active, `systemctl status` return a non-zero exit code, thus `systemctl status abrtd && systemctl status abrt-ccpp` would possibly show only the (inactive) status of `abrtd`, and nothing about `abrt-ccpp`.
Passing all service names to a single invocation of `systemctl status` show the status for both.

Similarly, we can restart both services in a single call, and that must be done as root (or use sudo). `sudo` makes it easier to copy-paste the snippet.