### PR TITLE
Use correct example for mailx.conf configuration

### DIFF
--- a/conf.rst
+++ b/conf.rst
@@ -26,6 +26,8 @@ Upon installation, ABRT and libreport place their respective configuration files
 ``/etc/abrt/plugins/``
     keeps configuration files used to override the default setting of ABRT's services and programs. For more information on some specific configuration files refer to :ref:`abrtspecific`.
 
+The configuration files expect Key-Value pairs separated by an equal sign. Quoting of the values is not supported.
+
 
 .. _abrtspecific:
 

--- a/examples.rst
+++ b/examples.rst
@@ -65,8 +65,9 @@ recipient) to ``/etc/libreport/plugins/mailx.conf``:
 
 ::
 
-    EmailFrom="ABRT Daemon <DoNotReply>"
-    EmailTo="devel@lists.project.org"
+    Subject = [abrt] a crash has been detected
+    EmailFrom = ABRT Daemon <DoNotReply>
+    EmailTo = devel@lists.project.org
 
 
 And the updated default configuration lines follow:


### PR DESCRIPTION
We do not support quoted values in configuration files.

Related: BZ#1477476

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>