### PR TITLE
developer.rst: Fix links, update man page details

### DIFF
--- a/developer.rst
+++ b/developer.rst
@@ -6,13 +6,11 @@ Documentation for developers
 Contributing
 ------------
 
-Send us patches to our mailing list::
+Send us patches to our mailing list at
+http://lists.fedorahosted.org/mailman/listinfo/crash-catcher
 
-        http://lists.fedorahosted.org/mailman/listinfo/crash-catcher
-
-or create a pull request for the corresponding repository::
-
-        https://github.com/abrt
+or create a pull request for the corresponding repository
+in `the abrt GitHub organization <https://github.com/abrt>`_.
 
 
 Where appropriate, your submission should come with a test —
@@ -35,23 +33,22 @@ common functions like ``_start`` from glibc or
 ``__kernel_vsyscall`` from Linux kernel.
 
 Such functions are listed in
-`satyr/lib/normalize.c <https://github.com/abrt/satyr/blob/master/lib/normalize.c>`_ file.
+`satyr/lib/normalize.c <https://github.com/abrt/satyr/blob/master/lib/normalize.c>`_.
 
 Writing man pages
 -----------------
 
-Man pages file can be written in AsciiDoc and then translated into the classic
-man page format. Man pages in AsciiDoc format are stored in doc/ directory. For example
-for libreport are placed in libreport/doc/.
+Abrt man pages are written in AsciiDoc, a minimal text markup language.
+The ``asciidoctor`` tool generates the formatted manpage files.
+Man pages in AsciiDoc format are stored in each project's ``doc/`` directory.
+For example, man pages for ``libreport`` are placed in
+`libreport/doc/ <https://github.com/abrt/libreport/blob/master/doc/>`_.
 
-To beter understand the issue, the following links shows man page written in Ascii::
+See `the Asciidoctor documentation <https://docs.asciidoctor.org/asciidoctor/latest/manpage-backend/>`_
+for more information on writing man pages in AsciiDoc.
+The `AsciiDoc Writer's Guide <https://asciidoctor.org/docs/asciidoc-writers-guide/>`_
+is a good resource for learning AsciiDoc syntax,
+although not all features are supported by the man page generator.
 
-    http://www.methods.co.nz/asciidoc/asciidoc.1.txt
-
-The translated pages look as follows::
-
-    http://www.methods.co.nz/asciidoc/asciidoc.1.css-embedded.html
-
-or::
-
-    man asciidoc
+The existing files in `abrt/doc/ <https://github.com/abrt/abrt/blob/master/doc/>`_
+can be used as templates for creating new man pages.


### PR DESCRIPTION
- Indented URLs get formatted as PRE blocks on ReadTheDocs, fixed to be real reStructuredText links.
- The AsciiDoc links were almost 10 years out of date, updated with a mix of new official docs and references to local project examples.
- (Not sure if the mailing list URL is still valid, but I didn't touch that except to fix the URL formatting.)